### PR TITLE
Adicionar o GLUA

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 ## Sistemas Operativos
 - [Centro Linux](https://centrolinux.pt/)
 - [Ubuntu Portugal](https://ubuntu-pt.org/)
+- [GLUA](https://glua.ua.pt/)
  
 ## Jogos
 - [Games Dev PT](https://www.facebook.com/gamedevspt)


### PR DESCRIPTION
GLUA é o Grupo de Linux da Universidade de Aveiro ([https://glua.ua.pt/](https://glua.ua.pt/))